### PR TITLE
Fix automatic crisis condition causing an error for non-GMs

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -108,7 +108,7 @@ export class FabulaUltimaActor extends Actor {
             let relEffect = effects.filter((effect) => effect.name === "Crisis");
 
             // Crisis is not yet assigned
-            if (relEffect.length == 0) {
+            if (relEffect.length == 0 && game.user.isGM) {
                 this.createEmbeddedDocuments("ActiveEffect", [
                     {
                         id: "crisis",
@@ -124,7 +124,7 @@ export class FabulaUltimaActor extends Actor {
             let effects = this.getEmbeddedCollection("ActiveEffect").contents;
             let relEffect = effects.filter((effect) => effect.name === "Crisis");
 
-            if (relEffect.length != 0) {
+            if (relEffect.length != 0 && game.user.isGM) {
                 this.deleteEmbeddedDocuments("ActiveEffect", [relEffect[0]._id]);
             }
         }


### PR DESCRIPTION
Adds a check in the actor's `_preparePlayerData` function that only applies the crisis condition if the current user is a GM.

Admittedly, I've never touched Foundry's API before today, but from testing, the prepare function runs on all clients whenever any client updates an actor. This does mean that the crisis condition won't apply if the GM isn't connected, and this could cause issues if there are multiple GMs, but it should fix the error in the standard single-GM-connected-at-all-times scenario.