### PR TITLE
Improve actor crisis detection

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -233,8 +233,8 @@ export class FabulaUltimaActor extends Actor {
                 let effects = this.getEmbeddedCollection("ActiveEffect").contents;
                 let relEffect = effects.filter((effect) => effect.name === "Crisis");
 
-                if (relEffect.length != 0) {
-                    this.deleteEmbeddedDocuments("ActiveEffect", [relEffect[0]._id]);
+                if (relEffect.length > 0) {
+                    this.deleteEmbeddedDocuments("ActiveEffect", relEffect.map(x => x._id));
                 }
             }
         }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -101,33 +101,6 @@ export class FabulaUltimaActor extends Actor {
         system.ip.value = clamp(system.ip.value, 0, system.ip.max);
 
         system.hp.crisis = Math.floor(system.hp.max / 2);
-
-        // Automatic application of Crisis status
-        if (system.hp.value <= system.hp.crisis) {
-            let effects = this.getEmbeddedCollection("ActiveEffect").contents;
-            let relEffect = effects.filter((effect) => effect.name === "Crisis");
-
-            // Crisis is not yet assigned
-            if (relEffect.length == 0 && game.user.isGM) {
-                this.createEmbeddedDocuments("ActiveEffect", [
-                    {
-                        id: "crisis",
-                        label: "Crisis",
-                        icon: "systems/fabulaultima/assets/ui/conditions/heart-beats.svg",
-                        statuses: ["crisis"],
-                    },
-                ]);
-            }
-        }
-        // The creature is not in Crisis or it is no longer in Crisis
-        else {
-            let effects = this.getEmbeddedCollection("ActiveEffect").contents;
-            let relEffect = effects.filter((effect) => effect.name === "Crisis");
-
-            if (relEffect.length != 0 && game.user.isGM) {
-                this.deleteEmbeddedDocuments("ActiveEffect", [relEffect[0]._id]);
-            }
-        }
     }
 
     _applyEquipment(actorData) {
@@ -231,6 +204,38 @@ export class FabulaUltimaActor extends Actor {
                 actorProp.system.statuses[key] = { active: false };
                 actorData.update(actorProp);
                 actorData.deleteEmbeddedDocuments("ActiveEffect", [relevantEffects[0]._id], {});
+            }
+        }
+    }
+
+    _onUpdate(data, options, userId) {
+        if (data.system?.hp && userId == game.userId) {
+            // The HP value has been changed, and we changed it
+            // Check for crisis
+            if (this.system.hp.value <= this.system.hp.crisis) {
+                let effects = this.getEmbeddedCollection("ActiveEffect").contents;
+                let relEffect = effects.filter((effect) => effect.name === "Crisis");
+
+                // Crisis is not yet assigned
+                if (relEffect.length == 0) {
+                    this.createEmbeddedDocuments("ActiveEffect", [
+                        {
+                            id: "crisis",
+                            label: "Crisis",
+                            icon: "systems/fabulaultima/assets/ui/conditions/heart-beats.svg",
+                            statuses: ["crisis"],
+                        },
+                    ]);
+                }
+            }
+            // The creature is not in Crisis or it is no longer in Crisis
+            else {
+                let effects = this.getEmbeddedCollection("ActiveEffect").contents;
+                let relEffect = effects.filter((effect) => effect.name === "Crisis");
+
+                if (relEffect.length != 0) {
+                    this.deleteEmbeddedDocuments("ActiveEffect", [relEffect[0]._id]);
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fabulaultima",
     "type": "module",
-    "version": "0.8.15b",
+    "version": "0.8.16b",
     "description": "Implementing Fabula Ultima in FoundryVTT.",
     "main": "index.js",
     "scripts": {

--- a/system.json
+++ b/system.json
@@ -5,7 +5,7 @@
     "authors": [{ "name": "razage", "discord": "razage", "url": "https://github.com/razage" }],
     "url": "https://github.com/razage/fabula-ultima-unofficial",
     "license": "LICENSE.txt",
-    "version": "0.8.15b",
+    "version": "0.8.16b",
     "compatibility": {
         "minimum": "10.291",
         "verified": "11.313"


### PR DESCRIPTION
It looks like players to have access to apply `ActiveEffects` to actors they own, so this replaces the fragile logic from #32 that depends on having exactly one GM connected with an onUpdate hook that makes the user who changed the HP value (be it a player or GM) apply or remove the effect.